### PR TITLE
Enumerble#min_by ruby backport

### DIFF
--- a/lib/cli/kit.rb
+++ b/lib/cli/kit.rb
@@ -1,4 +1,5 @@
 require 'cli/ui'
+require_relative '../ruby_backports/enumerable.rb'
 
 module CLI
   module Kit

--- a/lib/ruby_backports/enumerable.rb
+++ b/lib/ruby_backports/enumerable.rb
@@ -1,0 +1,5 @@
+module Enumerable
+  def min_by(n=1, &block)
+    sort_by(&block).first(n)
+  end if instance_method(:min_by).arity == 0
+end


### PR DESCRIPTION
`min_by` did not always take an argument, so backport if we didn't