### PR TITLE
Ignore unsupported signals.

### DIFF
--- a/lib/cli/kit/executor.rb
+++ b/lib/cli/kit/executor.rb
@@ -28,10 +28,14 @@ module CLI
       end
 
       def twrap(signal, handler)
-        prev_handler = trap(signal, handler)
-        yield
-      ensure
-        trap(signal, prev_handler)
+        return yield unless Signal.list.key?(signal)
+
+        begin
+          prev_handler = trap(signal, handler)
+          yield
+        ensure
+          trap(signal, prev_handler)
+        end
       end
 
       def quit_handler(_sig)


### PR DESCRIPTION
SIGINFO does not exist on Linux (except on Alpha apparently). Cli-kit tries to
install a handler for this signal, which is the correct thing to do on BSD or
Darwin, but just raises on Linux. This patch ignores signal handlers that are
installed for signals that do not exist on the current platform.