### PR TITLE
Add a test helper for system commands to cli kit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,10 @@ AllCops:
   Exclude: [ 'gen/template/**/*' ]
   TargetRubyVersion: 2.3
 
+Style/ClassAndModuleChildren:
+  Exclude:
+    - lib/cli/kit/support/test_helper.rb
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 

--- a/lib/cli/kit.rb
+++ b/lib/cli/kit.rb
@@ -12,6 +12,7 @@ module CLI
     autoload :Ini,             'cli/kit/ini'
     autoload :Levenshtein,     'cli/kit/levenshtein'
     autoload :Resolver,        'cli/kit/resolver'
+    autoload :Support,         'cli/kit/support'
     autoload :System,          'cli/kit/system'
 
     EXIT_FAILURE_BUT_NOT_BUG = 30

--- a/lib/cli/kit/support.rb
+++ b/lib/cli/kit/support.rb
@@ -1,0 +1,9 @@
+require 'cli/kit'
+
+module CLI
+  module Kit
+    module Support
+      autoload :TestHelper, 'cli/kit/support/test_helper'
+    end
+  end
+end

--- a/lib/cli/kit/support/test_helper.rb
+++ b/lib/cli/kit/support/test_helper.rb
@@ -1,0 +1,220 @@
+module CLI
+  module Kit
+    module Support
+      module TestHelper
+        def assert_all_commands_run
+          errors = CLI::Kit::System.capture_commands do
+            yield
+          end
+          assert_nil errors, message: errors
+        end
+
+        class FakeSuccess
+          def initialize(success)
+            @success = success
+          end
+
+          def success?
+            @success
+          end
+        end
+
+        module ::CLI
+          module Kit
+            module System
+              class << self
+                alias_method :original_system, :system
+                def system(*a, sudo: false, env: {}, **kwargs)
+                  expected_command = expected_command(*a, sudo: sudo, env: env)
+
+                  # In the case of an unexpected command, expected_command will be nil
+                  return FakeSuccess.new(false) if expected_command.nil?
+
+                  # Otherwise handle the command
+                  if expected_command[:allow]
+                    original_system(*a, sudo: sudo, env: env, **kwargs)
+                  else
+                    FakeSuccess.new(expected_command[:success])
+                  end
+                end
+
+                alias_method :original_capture2, :capture2
+                def capture2(*a, sudo: false, env: {}, **kwargs)
+                  expected_command = expected_command(*a, sudo: sudo, env: env)
+
+                  # In the case of an unexpected command, expected_command will be nil
+                  return [nil, FakeSuccess.new(false)] if expected_command.nil?
+
+                  # Otherwise handle the command
+                  if expected_command[:allow]
+                    original_capture2(*a, sudo: sudo, env: env, **kwargs)
+                  else
+                    [
+                      expected_command[:stdout],
+                      FakeSuccess.new(expected_command[:success]),
+                    ]
+                  end
+                end
+
+                alias_method :original_capture2e, :capture2e
+                def capture2e(*a, sudo: false, env: {}, **kwargs)
+                  expected_command = expected_command(*a, sudo: sudo, env: env)
+
+                  # In the case of an unexpected command, expected_command will be nil
+                  return [nil, FakeSuccess.new(false)] if expected_command.nil?
+
+                  # Otherwise handle the command
+                  if expected_command[:allow]
+                    original_capture2ecapture2e(*a, sudo: sudo, env: env, **kwargs)
+                  else
+                    [
+                      expected_command[:stdout],
+                      FakeSuccess.new(expected_command[:success]),
+                    ]
+                  end
+                end
+
+                alias_method :original_capture3, :capture3
+                def capture3(*a, sudo: false, env: {}, **kwargs)
+                  expected_command = expected_command(*a, sudo: sudo, env: env)
+
+                  # In the case of an unexpected command, expected_command will be nil
+                  return [nil, nil, FakeSuccess.new(false)] if expected_command.nil?
+
+                  # Otherwise handle the command
+                  if expected_command[:allow]
+                    original_capture3(*a, sudo: sudo, env: env, **kwargs)
+                  else
+                    [
+                      expected_command[:stdout],
+                      expected_command[:stderr],
+                      FakeSuccess.new(expected_command[:success]),
+                    ]
+                  end
+                end
+
+                # Sets up an expectation for a command and stubs out the call (unless allow is true)
+                #
+                # #### Parameters
+                # `*a` : the command, represented as a splat
+                # `stdout` : stdout to stub the command with (defaults to empty string)
+                # `stderr` : stderr to stub the command with (defaults to empty string)
+                # `allow` : allow determines if the command will be actually run, or stubbed. Defaults to nil (stub)
+                # `success` : success status to stub the command with (Defaults to nil)
+                # `sudo` : expectation of sudo being set or not (defaults to false)
+                # `env` : expectation of env being set or not (defaults to {})
+                #
+                # Note: Must set allow or success
+                #
+                def fake(*a, stdout: "", stderr: "", allow: nil, success: nil, sudo: false, env: {})
+                  raise ArgumentError, "success or allow must be set" if success.nil? && allow.nil?
+
+                  @delegate_open3 ||= {}
+                  @delegate_open3[a.join(' ')] = {
+                    expected: {
+                      sudo: sudo,
+                      env: env,
+                    },
+                    actual: {
+                      sudo: nil,
+                      env: nil,
+                    },
+                    stdout: stdout,
+                    stderr: stderr,
+                    allow: allow,
+                    success: success,
+                    run: false,
+                  }
+                end
+
+                # Captures all commands and returns errors
+                #
+                # #### Returns
+                # `error` (String) nil if no errors, otherwise a string representing the error
+                #
+                def capture_commands
+                  raise ArgumentError, 'block must be given' unless block_given?
+                  @delegate_open3 ||= {}
+                  yield
+                  determine_errors
+                ensure
+                  @delegate_open3 = {}
+                end
+
+                private
+
+                def determine_errors
+                  errors = {
+                    unexpected: [],
+                    not_run: [],
+                    other: {},
+                  }
+
+                  @delegate_open3.each do |cmd, opts|
+                    if opts[:unexpected]
+                      errors[:unexpected] << cmd
+                    elsif opts[:run]
+                      error = []
+
+                      if opts[:expected][:sudo] != opts[:actual][:sudo]
+                        error << "- sudo was supposed to be #{opts[:expected][:sudo]} but was #{opts[:actual][:sudo]}"
+                      end
+
+                      if opts[:expected][:env] != opts[:actual][:env]
+                        error << "- env was supposed to be #{opts[:expected][:env]} but was #{opts[:actual][:env]}"
+                      end
+
+                      errors[:other][cmd] = error.join("\n") unless error.empty?
+                    else
+                      errors[:not_run] << cmd
+                    end
+                  end
+
+                  final_error = []
+
+                  unless errors[:unexpected].empty?
+                    final_error << CLI::UI.fmt(<<~EOF)
+                    {{bold:Unexpected command invocations:}}
+                    {{command:#{errors[:unexpected].join("\n")}}}
+                    EOF
+                  end
+
+                  unless errors[:not_run].empty?
+                    final_error << CLI::UI.fmt(<<~EOF)
+                    {{bold:Expected commands were not run:}}
+                    {{command:#{errors[:not_run].join("\n")}}}
+                    EOF
+                  end
+
+                  unless errors[:other].empty?
+                    final_error << CLI::UI.fmt(<<~EOF)
+                    {{bold:Commands were not run as expected:}}
+                    #{errors[:other].map { |cmd, msg| "{{command:#{cmd}}}\n#{msg}" }.join("\n\n")}
+                    EOF
+                  end
+
+                  return nil if final_error.empty?
+                  "\n" + final_error.join("\n") # Initial new line for formatting reasons
+                end
+
+                def expected_command(*a, sudo: raise, env: raise)
+                  expected_cmd = @delegate_open3[a.join(' ')]
+
+                  if expected_cmd.nil?
+                    @delegate_open3[a.join(' ')] = { unexpected: true }
+                    return nil
+                  end
+
+                  expected_cmd[:run] = true
+                  expected_cmd[:actual][:sudo] = sudo
+                  expected_cmd[:actual][:env] = env
+                  expected_cmd
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/cli/kit/support/test_helper_test.rb
+++ b/test/cli/kit/support/test_helper_test.rb
@@ -1,0 +1,99 @@
+require 'test_helper'
+
+module CLI
+  module Kit
+    module Support
+      class TestHelperTest < MiniTest::Test
+        include CLI::Kit::Support::TestHelper
+
+        def test_when_all_commands_not_run
+          CLI::Kit::System.fake('banana', success: true)
+          errors = CLI::Kit::System.capture_commands do
+            # do nothing
+          end
+
+          expected_err = <<~EOF
+
+          Expected commands were not run:
+          banana
+          EOF
+          assert_equal expected_err, CLI::UI::ANSI.strip_codes(errors)
+        end
+
+        def test_when_unexpected_command
+          errors = CLI::Kit::System.capture_commands do
+            CLI::Kit::System.system('banana')
+          end
+
+          expected_err = <<~EOF
+
+          Unexpected command invocations:
+          banana
+          EOF
+          assert_equal expected_err, CLI::UI::ANSI.strip_codes(errors)
+        end
+
+        def test_when_commands_not_run_correctly
+          CLI::Kit::System.fake('banana', success: true)
+          CLI::Kit::System.fake('kiwi', success: true)
+
+          errors = CLI::Kit::System.capture_commands do
+            CLI::Kit::System.system('banana', sudo: true, env: { kiwi: false })
+            CLI::Kit::System.system('kiwi', sudo: true, env: { kiwi: false })
+          end
+
+          expected_err = <<~EOF
+
+          Commands were not run as expected:
+          banana
+          - sudo was supposed to be false but was true
+          - env was supposed to be {} but was {:kiwi=>false}
+
+          kiwi
+          - sudo was supposed to be false but was true
+          - env was supposed to be {} but was {:kiwi=>false}
+          EOF
+          assert_equal expected_err, CLI::UI::ANSI.strip_codes(errors)
+        end
+
+        def test_all_captures_and_system
+          CLI::Kit::System.fake('banana', success: true)
+          CLI::Kit::System.fake('kiwi', success: true)
+          CLI::Kit::System.fake('apple', success: true)
+          CLI::Kit::System.fake('orange', success: true)
+
+          errors = CLI::Kit::System.capture_commands do
+            CLI::Kit::System.system('banana').success?
+            CLI::Kit::System.capture2('kiwi').last.success?
+            CLI::Kit::System.capture2e('apple').last.success?
+            CLI::Kit::System.capture3('orange').last.success?
+          end
+
+          assert_nil errors, "errors should have been nil"
+        end
+
+        def test_assert_all_commands_run
+          CLI::Kit::System.fake('banana', success: true)
+          CLI::Kit::System.fake('kiwi', success: true)
+          CLI::Kit::System.fake('apple', success: true)
+          CLI::Kit::System.fake('orange', success: true)
+
+          assert_all_commands_run do
+            CLI::Kit::System.system('banana').success?
+            CLI::Kit::System.capture2('kiwi').last.success?
+            CLI::Kit::System.capture2e('apple').last.success?
+            CLI::Kit::System.capture3('orange').last.success?
+          end
+        end
+
+        def test_when_commands_run_properly
+          errors = CLI::Kit::System.capture_commands do
+            CLI::Kit::System.fake('banana', success: true)
+            assert CLI::Kit::System.system('banana').success?
+          end
+          assert_nil errors, "errors should have been nil"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
What this does
---
- Adds a test helper under `CLI::Kit::Support` to help with expectations and faking commands in CLI Kit
- adds `CLI::Kit::System.fake` similar to the internal `dev` fake, and `assert_all_commands_run` block to help with testing