### PR TITLE
Associate an ID with each run of a command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cli-kit (3.0.1)
-      cli-ui (>= 1.1.0)
+      cli-ui (>= 1.1.3)
 
 GEM
   remote: https://rubygems.org/
@@ -11,7 +11,7 @@ GEM
     ast (2.3.0)
     builder (3.2.3)
     byebug (9.0.6)
-    cli-ui (1.1.1)
+    cli-ui (1.1.3)
     metaclass (0.0.4)
     method_source (0.8.2)
     minitest (5.10.2)

--- a/cli-kit.gemspec
+++ b/cli-kit.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'cli-ui', '>= 1.1.0'
+  spec.add_runtime_dependency 'cli-ui', '>= 1.1.3'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
- Each execution has an associated ID that is prefixed in the logs
- If the command fails, we will prompt the user to tell us the ID