### PR TITLE
Add CLI::Kit::Logger for use in apps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cli-kit (3.0.1)
-      cli-ui (>= 1.1.3)
+      cli-ui (>= 1.1.4)
 
 GEM
   remote: https://rubygems.org/
@@ -11,7 +11,7 @@ GEM
     ast (2.3.0)
     builder (3.2.3)
     byebug (9.0.6)
-    cli-ui (1.1.3)
+    cli-ui (1.1.4)
     metaclass (0.0.4)
     method_source (0.8.2)
     minitest (5.10.2)

--- a/cli-kit.gemspec
+++ b/cli-kit.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'cli-ui', '>= 1.1.3'
+  spec.add_runtime_dependency 'cli-ui', '>= 1.1.4'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/gen/lib/gen.rb
+++ b/gen/lib/gen.rb
@@ -8,7 +8,10 @@ module Gen
 
   TOOL_NAME = 'cli-kit'
   ROOT      = File.expand_path('../../..', __FILE__)
-  LOG_FILE  = '/tmp/cli-kit.log'
+
+  TOOL_CONFIG_PATH = File.expand_path(File.join('~', '.config', TOOL_NAME))
+  LOG_FILE = File.join(TOOL_CONFIG_PATH, 'logs', 'log.log')
+  DEBUG_LOG_FILE = File.join(TOOL_CONFIG_PATH, 'logs', 'debug.log')
 
   autoload(:Generator, 'gen/generator')
 
@@ -17,6 +20,7 @@ module Gen
 
   autocall(:Config)  { CLI::Kit::Config.new(tool_name: TOOL_NAME) }
   autocall(:Command) { CLI::Kit::BaseCommand }
+  autocall(:Logger)  { CLI::Kit::Logger.new(debug_log_file: DEBUG_LOG_FILE) }
 
   autocall(:Executor) { CLI::Kit::Executor.new(log_file: LOG_FILE) }
   autocall(:Resolver) do

--- a/lib/cli/kit.rb
+++ b/lib/cli/kit.rb
@@ -11,6 +11,7 @@ module CLI
     autoload :Executor,        'cli/kit/executor'
     autoload :Ini,             'cli/kit/ini'
     autoload :Levenshtein,     'cli/kit/levenshtein'
+    autoload :Logger,          'cli/kit/logger'
     autoload :Resolver,        'cli/kit/resolver'
     autoload :Support,         'cli/kit/support'
     autoload :System,          'cli/kit/system'

--- a/lib/cli/kit/executor.rb
+++ b/lib/cli/kit/executor.rb
@@ -1,10 +1,12 @@
 require 'cli/kit'
 require 'English'
+require 'fileutils'
 
 module CLI
   module Kit
     class Executor
       def initialize(log_file:)
+        FileUtils.mkpath(File.dirname(log_file))
         @log_file = log_file
       end
 

--- a/lib/cli/kit/logger.rb
+++ b/lib/cli/kit/logger.rb
@@ -1,0 +1,68 @@
+require 'logger'
+require 'fileutils'
+
+module CLI
+  module Kit
+    class Logger
+      # Constructor for CLI::Kit::Logger
+      #
+      # @param debug_log_file [String] path to the file where debug logs should be stored
+      def initialize(debug_log_file:)
+        FileUtils.mkpath(File.dirname(debug_log_file))
+        @debug_logger = ::Logger.new(debug_log_file)
+      end
+
+      # Functionally equivalent to Logger#info
+      # Also logs to the debug file, taking into account CLI::UI::StdoutRouter.current_id
+      #
+      # @param msg [String] the message to log
+      def info(msg)
+        $stdout.puts CLI::UI.fmt(msg)
+        @debug_logger.info(format_debug(msg))
+      end
+
+      # Functionally equivalent to Logger#warn
+      # Also logs to the debug file, taking into account CLI::UI::StdoutRouter.current_id
+      #
+      # @param msg [String] the message to log
+      def warn(msg)
+        $stdout.puts CLI::UI.fmt("{{yellow:#{msg}}}")
+        @debug_logger.warn(format_debug(msg))
+      end
+
+      # Functionally equivalent to Logger#error
+      # Also logs to the debug file, taking into account CLI::UI::StdoutRouter.current_id
+      #
+      # @param msg [String] the message to log
+      def error(msg)
+        $stderr.puts CLI::UI.fmt("{{red:#{msg}}}")
+        @debug_logger.error(format_debug(msg))
+      end
+
+      # Functionally equivalent to Logger#fatal
+      # Also logs to the debug file, taking into account CLI::UI::StdoutRouter.current_id
+      #
+      # @param msg [String] the message to log
+      def fatal(msg)
+        $stderr.puts CLI::UI.fmt("{{red:{{bold:Fatal:}} #{msg}}}")
+        @debug_logger.fatal(format_debug(msg))
+      end
+
+      # Similar to Logger#debug, however will not output to STDOUT unless DEBUG env var is set
+      # Logs to the debug file, taking into account CLI::UI::StdoutRouter.current_id
+      #
+      # @param msg [String] the message to log
+      def debug(msg)
+        $stdout.puts CLI::UI.fmt(msg) if ENV['DEBUG']
+        @debug_logger.debug(format_debug(msg))
+      end
+
+      private
+
+      def format_debug(msg)
+        return msg unless CLI::UI::StdoutRouter.current_id
+        "[#{CLI::UI::StdoutRouter.current_id[:id]}] #{msg}"
+      end
+    end
+  end
+end

--- a/test/cli/kit/logger_test.rb
+++ b/test/cli/kit/logger_test.rb
@@ -1,0 +1,82 @@
+require 'test_helper'
+
+module CLI
+  module Kit
+    class LoggerTest < MiniTest::Test
+      def setup
+        super
+        @tmp_file = Tempfile.new('log').tap(&:close)
+        @logger = CLI::Kit::Logger.new(debug_log_file: @tmp_file.path)
+      end
+
+      def test_info
+        out, _ = capture_io do
+          @logger.info("hello")
+        end
+        assert_equal "\e[0mhello", out.chomp
+        assert_debug_log_entry("hello", "INFO")
+      end
+
+      def test_warn
+        out, _ = capture_io do
+          @logger.warn("hello")
+        end
+        assert_equal "\e[0;33mhello\e[0m", out.chomp
+        assert_debug_log_entry("hello", "WARN")
+      end
+
+      def test_error
+        _, err = capture_io do
+          @logger.error("hello")
+        end
+        assert_equal "\e[0;31mhello\e[0m", err.chomp
+        assert_debug_log_entry("hello", "ERROR")
+      end
+
+      def test_fatal
+        _, err = capture_io do
+          @logger.fatal("hello")
+        end
+        assert_equal "\e[0;31;1mFatal:\e[0;31m hello\e[0m", err.chomp
+        assert_debug_log_entry("hello", "FATAL")
+      end
+
+      def test_debug_without_debug_env
+        out, err = capture_io do
+          @logger.debug("hello")
+        end
+        assert_empty err.chomp
+        assert_empty out.chomp
+        assert_debug_log_entry("hello", "DEBUG")
+      end
+
+      def test_debug_with_debug_env
+        with_env('DEBUG' => '1') do
+          out, err = capture_io do
+            @logger.debug("hello")
+          end
+          assert_equal "\e[0mhello", out.chomp
+          assert_empty err.chomp
+          assert_debug_log_entry("hello", "DEBUG")
+        end
+      end
+
+      def test_with_thread_id_from_cli_ui
+        CLI::UI::StdoutRouter.with_id(on_streams: []) do |id|
+          capture_io do
+            @logger.debug("hello")
+          end
+          assert_debug_log_entry("hello", "DEBUG", id)
+        end
+      end
+
+      def assert_debug_log_entry(msg, level, id = nil)
+        timestamp_reg = "\\[\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d\\.\\d{6} #\\d+\\]"
+        reg = "#{level.chars.first}, #{timestamp_reg}\\s+#{level} -- :"
+        reg += " \\[\\d+\\]" if id
+        reg += " #{msg}"
+        assert_match Regexp.new(reg), File.read(@tmp_file.path).chomp
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,3 +21,11 @@ CLI::UI::StdoutRouter.enable
 
 require 'minitest/autorun'
 require 'mocha/mini_test'
+
+def with_env(env)
+  original_env_hash = ENV.to_h
+  ENV.replace(original_env_hash.merge(env))
+  yield
+ensure
+  ENV.replace(original_env_hash)
+end


### PR DESCRIPTION
Add a base logger in CLI Kit that handles a debug file, DEBUG env var, and CLI::UI::StdoutRouter.current_id