### PR TITLE
Allow logger to supress debug log, in cases where debug is also called

### DIFF
--- a/lib/cli/kit/logger.rb
+++ b/lib/cli/kit/logger.rb
@@ -16,36 +16,40 @@ module CLI
       # Also logs to the debug file, taking into account CLI::UI::StdoutRouter.current_id
       #
       # @param msg [String] the message to log
-      def info(msg)
+      # @param debug [Boolean] determines if the debug logger will receive the log (default true)
+      def info(msg, debug: true)
         $stdout.puts CLI::UI.fmt(msg)
-        @debug_logger.info(format_debug(msg))
+        @debug_logger.info(format_debug(msg)) if debug
       end
 
       # Functionally equivalent to Logger#warn
       # Also logs to the debug file, taking into account CLI::UI::StdoutRouter.current_id
       #
       # @param msg [String] the message to log
-      def warn(msg)
+      # @param debug [Boolean] determines if the debug logger will receive the log (default true)
+      def warn(msg, debug: true)
         $stdout.puts CLI::UI.fmt("{{yellow:#{msg}}}")
-        @debug_logger.warn(format_debug(msg))
+        @debug_logger.warn(format_debug(msg)) if debug
       end
 
       # Functionally equivalent to Logger#error
       # Also logs to the debug file, taking into account CLI::UI::StdoutRouter.current_id
       #
       # @param msg [String] the message to log
-      def error(msg)
+      # @param debug [Boolean] determines if the debug logger will receive the log (default true)
+      def error(msg, debug: true)
         $stderr.puts CLI::UI.fmt("{{red:#{msg}}}")
-        @debug_logger.error(format_debug(msg))
+        @debug_logger.error(format_debug(msg)) if debug
       end
 
       # Functionally equivalent to Logger#fatal
       # Also logs to the debug file, taking into account CLI::UI::StdoutRouter.current_id
       #
       # @param msg [String] the message to log
-      def fatal(msg)
+      # @param debug [Boolean] determines if the debug logger will receive the log (default true)
+      def fatal(msg, debug: true)
         $stderr.puts CLI::UI.fmt("{{red:{{bold:Fatal:}} #{msg}}}")
-        @debug_logger.fatal(format_debug(msg))
+        @debug_logger.fatal(format_debug(msg)) if debug
       end
 
       # Similar to Logger#debug, however will not output to STDOUT unless DEBUG env var is set

--- a/test/cli/kit/logger_test.rb
+++ b/test/cli/kit/logger_test.rb
@@ -17,12 +17,28 @@ module CLI
         assert_debug_log_entry("hello", "INFO")
       end
 
+      def test_info_without_debug_log
+        out, _ = capture_io do
+          @logger.info("hello", debug: false)
+        end
+        assert_equal "\e[0mhello", out.chomp
+        assert_empty File.read(@tmp_file.path).chomp
+      end
+
       def test_warn
         out, _ = capture_io do
           @logger.warn("hello")
         end
         assert_equal "\e[0;33mhello\e[0m", out.chomp
         assert_debug_log_entry("hello", "WARN")
+      end
+
+      def test_warn_without_debug_log
+        out, _ = capture_io do
+          @logger.warn("hello", debug: false)
+        end
+        assert_equal "\e[0;33mhello\e[0m", out.chomp
+        assert_empty File.read(@tmp_file.path).chomp
       end
 
       def test_error
@@ -33,12 +49,28 @@ module CLI
         assert_debug_log_entry("hello", "ERROR")
       end
 
+      def test_error_without_debug_log
+        _, err = capture_io do
+          @logger.error("hello", debug: false)
+        end
+        assert_equal "\e[0;31mhello\e[0m", err.chomp
+        assert_empty File.read(@tmp_file.path).chomp
+      end
+
       def test_fatal
         _, err = capture_io do
           @logger.fatal("hello")
         end
         assert_equal "\e[0;31;1mFatal:\e[0;31m hello\e[0m", err.chomp
         assert_debug_log_entry("hello", "FATAL")
+      end
+
+      def test_fatal_without_debug_log
+        _, err = capture_io do
+          @logger.fatal("hello", debug: false)
+        end
+        assert_equal "\e[0;31;1mFatal:\e[0;31m hello\e[0m", err.chomp
+        assert_empty File.read(@tmp_file.path).chomp
       end
 
       def test_debug_without_debug_env


### PR DESCRIPTION
If you want to call
```ruby
info("blah")
debug("detailed blah")
```
you dont want info _also_ being in the debug log, so allow the user to suppress that