### PR TITLE
Update to Mocha 1.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'mocha', require: false
+  gem 'mocha', '~> 1.5.0', require: false
   gem 'minitest', '>= 5.0.0', require: false
   gem 'minitest-reporters', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mocha (1.2.1)
+    mocha (1.5.0)
       metaclass (~> 0.0.1)
     parallel (1.11.2)
     parser (2.4.0.0)
@@ -49,7 +49,7 @@ DEPENDENCIES
   method_source
   minitest (>= 5.0.0)
   minitest-reporters
-  mocha
+  mocha (~> 1.5.0)
   rake (~> 10.0)
   rubocop
 

--- a/gen/template/Gemfile
+++ b/gen/template/Gemfile
@@ -4,7 +4,7 @@ gem 'cli-kit', '~> __cli-kit-version__'
 gem 'cli-ui', '~> __cli-ui-version__'
 
 group :test do
-  gem 'mocha', require: false
+  gem 'mocha', '~> 1.5.0', require: false
   gem 'minitest', '>= 5.0.0', require: false
   gem 'minitest-reporters', require: false
 end

--- a/gen/template/test/test_helper.rb
+++ b/gen/template/test/test_helper.rb
@@ -18,4 +18,5 @@ require 'bundler/setup'
 CLI::UI::StdoutRouter.enable
 
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require "minitest/unit"
+require 'mocha/minitest'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,7 +20,8 @@ require 'byebug'
 CLI::UI::StdoutRouter.enable
 
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require "minitest/unit"
+require 'mocha/minitest'
 
 def with_env(env)
   original_env_hash = ENV.to_h


### PR DESCRIPTION
 - Fixes warning that `mocha/mini_test` is deprecated