### PR TITLE
Add SubmoduleLoader utility

### DIFF
--- a/gen/lib/gen.rb
+++ b/gen/lib/gen.rb
@@ -5,6 +5,7 @@ CLI::UI::StdoutRouter.enable
 
 module Gen
   extend CLI::Kit::Autocall
+  extend CLI::Kit::SubmoduleLoader
 
   TOOL_NAME = 'cli-kit'
   ROOT      = File.expand_path('../../..', __FILE__)
@@ -13,10 +14,9 @@ module Gen
   LOG_FILE = File.join(TOOL_CONFIG_PATH, 'logs', 'log.log')
   DEBUG_LOG_FILE = File.join(TOOL_CONFIG_PATH, 'logs', 'debug.log')
 
-  autoload(:Generator, 'gen/generator')
-
-  autoload(:EntryPoint, 'gen/entry_point')
-  autoload(:Commands,   'gen/commands')
+  autoload_submodule :Generator
+  autoload_submodule :EntryPoint
+  autoload_submodule :Commands
 
   autocall(:Config)  { CLI::Kit::Config.new(tool_name: TOOL_NAME) }
   autocall(:Command) { CLI::Kit::BaseCommand }

--- a/gen/lib/gen/commands.rb
+++ b/gen/lib/gen/commands.rb
@@ -2,17 +2,21 @@ require 'gen'
 
 module Gen
   module Commands
+    extend CLI::Kit::SubmoduleLoader
+
     Registry = CLI::Kit::CommandRegistry.new(
       default: 'help',
       contextual_resolver: nil
     )
 
-    def self.register(const, cmd, path)
-      autoload(const, path)
+    def self.register(const, cmd = nil)
+      autoload_submodule const
+
+      cmd = CLI::Kit::Util.dash_case(const.to_s) if cmd.nil?
       Registry.add(->() { const_get(const) }, cmd)
     end
 
-    register :Help, 'help', 'gen/commands/help'
-    register :New,  'new',  'gen/commands/new'
+    register :Help
+    register :New
   end
 end

--- a/gen/template/lib/__app__.rb
+++ b/gen/template/lib/__app__.rb
@@ -5,13 +5,14 @@ CLI::UI::StdoutRouter.enable
 
 module __App__
   extend CLI::Kit::Autocall
+  extend CLI::Kit::SubmoduleLoader
 
   TOOL_NAME = '__app__'
   ROOT      = File.expand_path('../..', __FILE__)
   LOG_FILE  = '/tmp/__app__.log'
 
-  autoload(:EntryPoint, '__app__/entry_point')
-  autoload(:Commands,   '__app__/commands')
+  autoload_submodule :EntryPoint
+  autoload_submodule :Commands
 
   autocall(:Config)  { CLI::Kit::Config.new(tool_name: TOOL_NAME) }
   autocall(:Command) { CLI::Kit::BaseCommand }

--- a/gen/template/lib/__app__/commands.rb
+++ b/gen/template/lib/__app__/commands.rb
@@ -2,17 +2,21 @@ require '__app__'
 
 module __App__
   module Commands
+    extend CLI::Kit::SubmoduleLoader
+
     Registry = CLI::Kit::CommandRegistry.new(
       default: 'help',
       contextual_resolver: nil
     )
 
-    def self.register(const, cmd, path)
-      autoload(const, path)
+    def self.register(const, cmd = nil)
+      autoload_submodule const
+
+      cmd = CLI::Kit::Util.dash_case(const.to_s) if cmd.nil?
       Registry.add(->() { const_get(const) }, cmd)
     end
 
-    register :Example, 'example', '__app__/commands/example'
-    register :Help,    'help',    '__app__/commands/help'
+    register :Example
+    register :Help
   end
 end

--- a/lib/cli/kit.rb
+++ b/lib/cli/kit.rb
@@ -1,20 +1,23 @@
 require 'cli/ui'
 require 'cli/kit/ruby_backports/enumerable'
+require 'cli/kit/submodule_loader'
 
 module CLI
   module Kit
-    autoload :Autocall,        'cli/kit/autocall'
-    autoload :BaseCommand,     'cli/kit/base_command'
-    autoload :CommandRegistry, 'cli/kit/command_registry'
-    autoload :Config,          'cli/kit/config'
-    autoload :ErrorHandler,    'cli/kit/error_handler'
-    autoload :Executor,        'cli/kit/executor'
-    autoload :Ini,             'cli/kit/ini'
-    autoload :Levenshtein,     'cli/kit/levenshtein'
-    autoload :Logger,          'cli/kit/logger'
-    autoload :Resolver,        'cli/kit/resolver'
-    autoload :Support,         'cli/kit/support'
-    autoload :System,          'cli/kit/system'
+    extend CLI::Kit::SubmoduleLoader
+
+    autoload_submodule :Autocall
+    autoload_submodule :BaseCommand
+    autoload_submodule :CommandRegistry
+    autoload_submodule :Config
+    autoload_submodule :ErrorHandler
+    autoload_submodule :Executor
+    autoload_submodule :Ini
+    autoload_submodule :Levenshtein
+    autoload_submodule :Logger
+    autoload_submodule :Resolver
+    autoload_submodule :Support
+    autoload_submodule :System
 
     EXIT_FAILURE_BUT_NOT_BUG = 30
     EXIT_BUG                 = 1

--- a/lib/cli/kit/submodule_loader.rb
+++ b/lib/cli/kit/submodule_loader.rb
@@ -24,18 +24,19 @@ module CLI
   module Kit
     module SubmoduleLoader
       def self.included(_mod)
-        raise "#{SubmoduleLoader} should be used with 'extend', not 'include'"
+        raise "#{self} should be used with 'extend', not 'include'"
       end
 
       def self.extended(mod)
         file = caller_locations(1, 1).first.absolute_path
         filename = File.basename(file, '.rb')
         autoload_dir = Pathname.new(file).parent.join(filename).expand_path
+        mod.class_eval { @autoload_dir = autoload_dir }
+      end
 
-        mod.define_singleton_method(:autoload_submodule) do |sym|
-          submodule_name = CLI::Kit::Util.snake_case(sym.to_s)
-          mod.autoload(sym, autoload_dir.join(submodule_name))
-        end
+      def autoload_submodule(sym)
+        submodule_name = CLI::Kit::Util.snake_case(sym.to_s)
+        autoload(sym, @autoload_dir.join(submodule_name))
       end
     end
   end

--- a/lib/cli/kit/submodule_loader.rb
+++ b/lib/cli/kit/submodule_loader.rb
@@ -1,0 +1,42 @@
+require 'pathname'
+require 'cli/kit/util'
+
+# Utility to register submodules or classes with autoload,
+# if they follow the pattern of Foo::PascalCase => foo/snake_case.rb
+#
+# Usage:
+#
+# /path/to/lib/app.rb
+# module App
+#   extend CLI::Kit::SubmoduleLoader
+#   autoload_submodule :Foo        # /path/to/lib/app/foo.rb
+# end
+#
+# /path/to/lib/app/foo.rb
+# module App
+#   module Foo
+#     extend CLI::Kit::SubmoduleLoader
+#     autoload_submodule :Bar      # /path/to/lib/app/foo/bar.rb
+#     autoload_submodule :Baz      # /path/to/lib/app/foo/baz.rb
+#   end
+# end
+module CLI
+  module Kit
+    module SubmoduleLoader
+      def self.included(_mod)
+        raise "#{SubmoduleLoader} should be used with 'extend', not 'include'"
+      end
+
+      def self.extended(mod)
+        file = caller_locations(1, 1).first.absolute_path
+        filename = File.basename(file, '.rb')
+        autoload_dir = Pathname.new(file).parent.join(filename).expand_path
+
+        mod.define_singleton_method(:autoload_submodule) do |sym|
+          submodule_name = CLI::Kit::Util.snake_case(sym.to_s)
+          mod.autoload(sym, autoload_dir.join(submodule_name))
+        end
+      end
+    end
+  end
+end

--- a/lib/cli/kit/support.rb
+++ b/lib/cli/kit/support.rb
@@ -3,7 +3,9 @@ require 'cli/kit'
 module CLI
   module Kit
     module Support
-      autoload :TestHelper, 'cli/kit/support/test_helper'
+      extend CLI::Kit::SubmoduleLoader
+
+      autoload_submodule :TestHelper
     end
   end
 end

--- a/lib/cli/kit/util.rb
+++ b/lib/cli/kit/util.rb
@@ -1,0 +1,131 @@
+module CLI
+  module Kit
+    module Util
+      class << self
+        def snake_case(camel_case, seperator = "_")
+          camel_case.to_s # MyCoolThing::MyAPIModule
+            .gsub(/::/, '/') # MyCoolThing/MyAPIModule
+            .gsub(/([A-Z]+)([A-Z][a-z])/, "\\1#{seperator}\\2") # MyCoolThing::MyAPI_Module
+            .gsub(/([a-z\d])([A-Z])/, "\\1#{seperator}\\2") # My_Cool_Thing::My_API_Module
+            .downcase # my_cool_thing/my_api_module
+        end
+
+        def dash_case(camel_case)
+          snake_case(camel_case, '-')
+        end
+
+        # The following methods is taken from activesupport
+        #
+        # https://github.com/rails/rails/blob/d66e7835bea9505f7003e5038aa19b6ea95ceea1/activesupport/lib/active_support/core_ext/string/strip.rb
+        #
+        # All credit for this method goes to the original authors.
+        # The code is used under the MIT license.
+        #
+        # Strips indentation by removing the amount of leading whitespace in the least indented
+        # non-empty line in the whole string
+        #
+        def strip_heredoc(str)
+          str.gsub(/^#{str.scan(/^[ \t]*(?=\S)/).min}/, "".freeze)
+        end
+
+        # Execute a block within the context of a variable enviroment
+        #
+        def with_environment(environment, value)
+          return yield unless environment
+
+          old_env = ENV[environment]
+          begin
+            ENV[environment] = value
+            yield
+          ensure
+            old_env ? ENV[environment] = old_env : ENV.delete(environment)
+          end
+        end
+
+        # Converts an integer representing bytes into a human readable format
+        #
+        def to_filesize(bytes)
+          {
+            'B'  => 1024,
+            'KB' => 1024 * 1024,
+            'MB' => 1024 * 1024 * 1024,
+            'GB' => 1024 * 1024 * 1024 * 1024,
+            'TB' => 1024 * 1024 * 1024 * 1024 * 1024,
+          }.each_pair { |e, s| return "#{(bytes.to_f / (s / 1024)).round(2)}#{e}" if bytes < s }
+        end
+
+        # Dir.chdir, when invoked in block form, complains when we call chdir
+        # again recursively. There's no apparent good reason for this, so we
+        # simply implement our own block form of Dir.chdir here.
+        def with_dir(dir)
+          prev = Dir.pwd
+          Dir.chdir(dir)
+          yield
+        ensure
+          Dir.chdir(prev)
+        end
+
+        def with_tmp_dir
+          require 'fileutils'
+          dir = Dir.mktmpdir
+          with_dir(dir) do
+            yield(dir)
+          end
+        ensure
+          FileUtils.remove_entry(dir)
+        end
+
+        # Standard way of checking for CI / Tests
+        def testing?
+          ci? || ENV['TEST']
+        end
+
+        # Set only in IntegrationTest#session; indicates that the process was
+        # called by `session.execute` from an IntegrationTest subclass.
+        def integration_test_session?
+          ENV['INTEGRATION_TEST_SESSION']
+        end
+
+        # Standard way of checking for CI
+        def ci?
+          ENV['CI']
+        end
+
+        # Must call retry_after on the result in order to execute the block
+        #
+        # Example usage:
+        #
+        # CLI::Kit::Util.begin do
+        #   might_raise_if_costly_prep_not_done()
+        # end.retry_after(ExpectedError) do
+        #   costly_prep()
+        # end
+        def begin(&block_that_might_raise)
+          Retrier.new(block_that_might_raise)
+        end
+      end
+
+      class Retrier
+        def initialize(block_that_might_raise)
+          @block_that_might_raise = block_that_might_raise
+        end
+
+        def retry_after(exception = StandardError, retries: 1, &before_retry)
+          @block_that_might_raise.call
+        rescue exception => e
+          raise if (retries -= 1) < 0
+          if before_retry
+            if before_retry.arity == 0
+              yield
+            else
+              yield e
+            end
+          end
+          retry
+        end
+      end
+
+      private_constant :Retrier
+    end
+  end
+end

--- a/test/cli/kit/util_test.rb
+++ b/test/cli/kit/util_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require 'English'
+
+module CLI
+  module Kit
+    class UtilTest < MiniTest::Test
+      def test_snake_case
+        assert_equal '', CLI::Kit::Util.snake_case('')
+        assert_equal 'a', CLI::Kit::Util.snake_case('A')
+        assert_equal 'aa', CLI::Kit::Util.snake_case('AA')
+        assert_equal 'a', CLI::Kit::Util.snake_case('a')
+        assert_equal 'foo/bar_b', CLI::Kit::Util.snake_case('Foo::BarB')
+      end
+
+      def test_to_filesize
+        assert_equal '12.9KB',  CLI::Kit::Util.to_filesize(13212)
+        assert_equal '126.0MB', CLI::Kit::Util.to_filesize(132121322)
+        assert_equal '1.23GB',  CLI::Kit::Util.to_filesize(1321213212)
+        assert_equal '12.02TB', CLI::Kit::Util.to_filesize(13212132121999)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Also ported Dev::Util, only including relevant bits
- Avoids repetition and manually having to do the snake_case conversion
- Encourages a standard structure (convention over configuration)
- Avoids having to realign lines when a longer symbol is added.

Before:
```rb
module CLI
  module Kit
    autoload :Autocall,     'cli/kit/autocall'
    autoload :BaseCommand,  'cli/kit/base_command'
  end
end

```

After:
```rb
module CLI
  module Kit
    module Support
      extend CLI::Kit::AutoloadSubmodule

      autoload_submodule :Autocall
      autoload_submodule :BaseCommand
    end
  end
end
```
