### PR TITLE
Fix bug with '=' in values of ini file

### DIFF
--- a/lib/cli/kit/ini.rb
+++ b/lib/cli/kit/ini.rb
@@ -39,7 +39,7 @@ module CLI
 
           # Otherwise set the values
           else
-            k, v = l.split('=').map(&:strip)
+            k, v = l.split('=', 2).map(&:strip)
             set_val(k, v)
           end
         end

--- a/test/cli/kit/ini_test.rb
+++ b/test/cli/kit/ini_test.rb
@@ -6,7 +6,7 @@ module CLI
       def test_with_section_directives
         helper = Ini.new(fixture_path('ini_with_heading.conf'))
         assert_equal(
-          { '[global]' => { 'key' => 'val', 'key2' => 'val' } },
+          { '[global]' => { 'key' => 'val', 'key2' => 'val2=' } },
           helper.parse
         )
       end
@@ -14,7 +14,7 @@ module CLI
       def test_without_section_directives
         helper = Ini.new(fixture_path('ini_without_heading.conf'))
         assert_equal(
-          { 'key' => 'val', 'key2' => 'val' },
+          { 'key' => 'val', 'key2' => 'val2=' },
           helper.parse
         )
       end
@@ -24,9 +24,9 @@ module CLI
         assert_equal(
           {
             'key' => 'val',
-            'key2' => 'val',
-            '[global]' => { 'key' => 'val', 'key2' => 'val' },
-            'key3' => 'val',
+            'key2' => 'val2=',
+            '[global]' => { 'key' => 'val', 'key2' => 'val2=' },
+            'key3' => 'val3',
           }, helper.parse
         )
       end

--- a/test/fixtures/ini_with_and_without_heading.conf
+++ b/test/fixtures/ini_with_and_without_heading.conf
@@ -1,8 +1,8 @@
 key = val
-key2 = val
+key2 = val2=
 
 [global]
 key = val
-key2 = val
+key2 = val2=
 
-key3 = val
+key3 = val3

--- a/test/fixtures/ini_with_heading.conf
+++ b/test/fixtures/ini_with_heading.conf
@@ -1,3 +1,3 @@
 [global]
 key = val
-key2 = val
+key2 = val2=

--- a/test/fixtures/ini_without_heading.conf
+++ b/test/fixtures/ini_without_heading.conf
@@ -1,2 +1,2 @@
 key = val
-key2 = val
+key2 = val2=


### PR DESCRIPTION
The `pip.conf` file can contain a (packagecloud) etag with trailing `=` chars.
This causes the ini parser to incorrectly parse the pip config file and thus run `update tokens in pip config` on **each** run.