### PR TITLE
Have command resolution behave more similar to shells.

### DIFF
--- a/lib/cli/kit/system.rb
+++ b/lib/cli/kit/system.rb
@@ -191,9 +191,13 @@ module CLI
           # If only one argument was provided, make sure it's interpreted by a shell.
           return ["true ; " + a[0]] if a.size == 1
           return a if a.first.include?('/')
-          item = env.fetch('PATH', '').split(':').detect do |f|
-            File.exist?("#{f}/#{a.first}")
+
+          paths = env.fetch('PATH', '').split(':')
+          item = paths.detect do |f|
+            command_path = "#{f}/#{a.first}"
+            File.executable?(command_path) && File.file?(command_path)
           end
+
           a[0] = "#{item}/#{a.first}" if item
           a
         end

--- a/test/cli/kit/system_test.rb
+++ b/test/cli/kit/system_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 module CLI
   module Kit
+    include CLI::Kit::Support::TestHelper
+
     class SystemTest < MiniTest::Test
       def test_split_partial_characters_doesnt_split_single_byte_characters
         str = "ルビー is cool"
@@ -31,6 +33,44 @@ module CLI
         str = "Hello\x83\x83\x83\x83\x83\x83\x83\x83"
 
         assert_equal [str, ''], System.split_partial_characters(str)
+      end
+
+      def test_system_finds_system_ruby_instead_of_local_script
+        CLI::Kit::System.fake("ruby", "-e", "puts 'system ruby'", allow: true)
+
+        with_script_in_tmpdir("ruby") do |tmpdir|
+          Dir.chdir(tmpdir) do
+            out, stat = System.capture2("ruby", "-e", "puts 'system ruby'", env: ENV)
+
+            assert stat, message: "expected command to successfully run"
+            assert_equal "system ruby", out.chomp
+          end
+        end
+      end
+
+      def test_system_finds_ruby_script_with_path_modifications
+        CLI::Kit::System.fake("ruby", "-e", "puts 'system ruby'", allow: true)
+
+        with_script_in_tmpdir("ruby") do |tmpdir|
+          with_env("PATH" => "#{tmpdir}:#{ENV['PATH']}") do
+            out, stat = System.capture2("ruby", "-e", "puts 'system ruby'", env: ENV)
+
+            assert stat, message: "expected command to successfully run"
+            assert_equal "from script", out.chomp
+          end
+        end
+      end
+
+      private
+
+      def with_script_in_tmpdir(script_name)
+        Dir.mktmpdir do |tmpdir|
+          File.open(File.join(tmpdir, script_name), "w", 0755) do |f|
+            f.write("#!/bin/sh\n")
+            f.write("echo from script\n")
+          end
+          yield tmpdir
+        end
       end
     end
   end


### PR DESCRIPTION
This comes with two additions:
- Ignore directories and files that cannot be executed.
- Include executables in the current working directory (after everything else in `PATH`).

This is how (by default) both bash [1] and zsh [2] works (both require a little more digging beyond what I've linked to to find the functionality that checks the current working directory).

[1] http://git.savannah.gnu.org/gitweb/?p=bash.git;a=blob;f=findcmd.c;hb=64447609994bfddeef1061948022c074093e9a9f#l389)
[2] https://github.com/zsh-users/zsh/blob/ad9f07e66fded8a44adba15d576960cef587f9d4/Src/utils.c#L828-L830