### PR TITLE
No need to require json -- not used by example

### DIFF
--- a/gen/template/lib/__app__/commands/example.rb
+++ b/gen/template/lib/__app__/commands/example.rb
@@ -1,5 +1,4 @@
 require '__app__'
-require 'json'
 
 module __App__
   module Commands


### PR DESCRIPTION
The `example` command added by default to every app requires the `json` library.
However, the library is not used by the `example` command.
The `require` statement can probably be removed.

_(Note: this is my first contribution to this project -- please let me know if I missed something! Thanks)_