### PR TITLE
Avoid overwriting error

### DIFF
--- a/lib/cli/kit/executor.rb
+++ b/lib/cli/kit/executor.rb
@@ -16,8 +16,14 @@ module CLI
             begin
               command.call(args, command_name)
             rescue => e
-              $stderr.puts "This command ran with ID: #{id}"
-              $stderr.puts "Please include this information in any issues/report along with relevant logs"
+              begin
+                $stderr.puts "This command ran with ID: #{id}"
+                $stderr.puts "Please include this information in any issues/report along with relevant logs"
+              rescue SystemCallError
+                # Outputting to stderr is best-effort.  Avoid raising another error when outputting debug info so that
+                # we can detect and log the original error, which may even be the source of this error.
+                nil
+              end
               raise e
             end
           end


### PR DESCRIPTION
Make outputting to stderr best-effort.  Avoid raising another error when outputting debug info so that we can detect and log the original error, which may even be the source of the stream closed error.