### PR TITLE
Add a "command" tag to stats

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,4 +53,4 @@ DEPENDENCIES
   rubocop (~> 0.56.0)
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/lib/cli/kit/base_command.rb
+++ b/lib/cli/kit/base_command.rb
@@ -17,7 +17,7 @@ module CLI
 
       def self.call(args, command_name)
         cmd = new
-        stats_tags = cmd.stats_tags(args)
+        stats_tags = cmd.stats_tags(args, command_name)
         begin
           statsd_increment("cli.command.invoked", tags: stats_tags)
           statsd_time("cli.command.time", tags: stats_tags) do
@@ -30,8 +30,9 @@ module CLI
         end
       end
 
-      def stats_tags(args)
+      def stats_tags(args, command_name)
         tags = ["task:#{self.class}"]
+        tags << "command:#{command_name}" if command_name
         tags << "subcommand:#{args.first}" if args&.first && has_subcommands?
         tags
       end

--- a/test/cli/kit/base_command_test.rb
+++ b/test/cli/kit/base_command_test.rb
@@ -23,7 +23,7 @@ module CLI
       end
 
       def expected_tags
-        ["task:CLI::Kit::BaseCommandTest::ExampleCommand"]
+        %w(task:CLI::Kit::BaseCommandTest::ExampleCommand command:command)
       end
 
       def test_self_call_sends_statsd_on_success


### PR DESCRIPTION
This allows tracking granular metrics even on custom commands.