### PR TITLE
Enhance Configuration Testing and Ini Configuration

### DIFF
--- a/lib/cli/kit/ini.rb
+++ b/lib/cli/kit/ini.rb
@@ -15,8 +15,12 @@ module CLI
     class Ini
       attr_accessor :ini
 
-      def initialize(path = nil, default_section: nil, convert_types: true)
-        @config = File.readlines(path) if path && File.exist?(path)
+      def initialize(path = nil, config: nil, default_section: nil, convert_types: true)
+        @config = if path && File.exist?(path)
+          File.readlines(path)
+        elsif config
+          config.lines
+        end
         @ini = {}
         @current_key = nil
         @default_section = default_section

--- a/lib/cli/kit/support/test_helper.rb
+++ b/lib/cli/kit/support/test_helper.rb
@@ -19,6 +19,24 @@ module CLI
           assert_all_commands_run
         end
 
+        module FakeConfig
+          require 'tmpdir'
+          require 'fileutils'
+
+          def setup
+            super
+            @tmpdir = Dir.mktmpdir
+            @prev_xdg = ENV['XDG_CONFIG_HOME']
+            ENV['XDG_CONFIG_HOME'] = @tmpdir
+          end
+
+          def teardown
+            FileUtils.rm_rf(@tmpdir)
+            ENV['XDG_CONFIG_HOME'] = @prev_xdg
+            super
+          end
+        end
+
         class FakeSuccess
           def initialize(success)
             @success = success

--- a/test/cli/kit/config_test.rb
+++ b/test/cli/kit/config_test.rb
@@ -1,24 +1,14 @@
 require 'test_helper'
-require 'tmpdir'
-require 'fileutils'
 
 module CLI
   module Kit
     class ConfigTest < MiniTest::Test
+      include CLI::Kit::Support::TestHelper::FakeConfig
+
       def setup
         super
-
-        @tmpdir = Dir.mktmpdir
-        @prev_xdg = ENV['XDG_CONFIG_HOME']
-        ENV['XDG_CONFIG_HOME'] = @tmpdir
         @file = File.join(@tmpdir, 'tool', 'config')
         @config = Config.new(tool_name: 'tool')
-      end
-
-      def teardown
-        FileUtils.rm_rf(@tmpdir)
-        ENV['XDG_CONFIG_HOME'] = @prev_xdg
-        super
       end
 
       def test_config_get_returns_false_for_not_existant_key

--- a/test/cli/kit/ini_test.rb
+++ b/test/cli/kit/ini_test.rb
@@ -11,6 +11,14 @@ module CLI
         )
       end
 
+      def test_with_config_string
+        helper = Ini.new(config: "key=val\nkey2=val2")
+        assert_equal(
+          { 'key' => 'val', 'key2' => 'val2' },
+          helper.parse
+        )
+      end
+
       def test_without_section_directives
         helper = Ini.new(fixture_path('ini_without_heading.conf'))
         assert_equal(


### PR DESCRIPTION
What this does
---
- Makes the ini parser accept a config string directly, changing `path` to a keyword to align it with the rest of the method signature
- Makes the config faking in the test suite an includeable module so that downstream apps can use it too.