### PR TITLE
Rescue and count all exceptions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cli-kit (3.1.0)
+    cli-kit (3.2.0)
       cli-ui (>= 1.1.4)
 
 GEM

--- a/cli-kit.gemspec
+++ b/cli-kit.gemspec
@@ -6,8 +6,8 @@ require 'cli/kit/version'
 Gem::Specification.new do |spec|
   spec.name          = 'cli-kit'
   spec.version       = CLI::Kit::VERSION
-  spec.authors       = ['Burke Libbey', 'Julian Nadeau', 'Lisa Ugray']
-  spec.email         = ['burke.libbey@shopify.com', 'julian.nadeau@shopify.com', 'lisa.ugray@shopify.com']
+  spec.authors       = ['Burke Libbey', 'Aaron Olson', 'Lisa Ugray']
+  spec.email         = ['burke.libbey@shopify.com', 'aaron.olson@shopify.com', 'lisa.ugray@shopify.com']
 
   spec.summary       = 'Terminal UI framework extensions'
   spec.description   = 'Terminal UI framework extensions'

--- a/lib/cli/kit/base_command.rb
+++ b/lib/cli/kit/base_command.rb
@@ -24,7 +24,7 @@ module CLI
             cmd.call(args, command_name)
           end
           statsd_increment("cli.command.success", tags: stats_tags)
-        rescue Exception => e
+        rescue Exception => e # rubocop:disable Lint/RescueException
           statsd_increment("cli.command.exception", tags: stats_tags + ["exception:#{e.class}"])
           raise e
         end

--- a/lib/cli/kit/base_command.rb
+++ b/lib/cli/kit/base_command.rb
@@ -24,7 +24,7 @@ module CLI
             cmd.call(args, command_name)
           end
           statsd_increment("cli.command.success", tags: stats_tags)
-        rescue => e
+        rescue Exception => e
           statsd_increment("cli.command.exception", tags: stats_tags + ["exception:#{e.class}"])
           raise e
         end

--- a/lib/cli/kit/version.rb
+++ b/lib/cli/kit/version.rb
@@ -1,5 +1,5 @@
 module CLI
   module Kit
-    VERSION = "3.1.0"
+    VERSION = "3.2.0"
   end
 end

--- a/test/cli/kit/base_command_test.rb
+++ b/test/cli/kit/base_command_test.rb
@@ -79,15 +79,15 @@ module CLI
         )
         ExampleCommand.any_instance.expects(:call)
           .with(['test'], "command")
-          .raises(RuntimeError, 'something went wrong.')
+          .raises(CLI::Kit::AbortSilent, 'something went wrong.')
 
         ExampleCommand.expects(:stat).with(
           :increment,
           "cli.command.exception",
-          tags: expected_tags + ["subcommand:test", "exception:RuntimeError"]
+          tags: expected_tags + ["subcommand:test", "exception:CLI::Kit::AbortSilent"]
         )
 
-        e = assert_raises RuntimeError do
+        e = assert_raises CLI::Kit::AbortSilent do
           ExampleCommand.call(['test'], "command")
         end
         assert_equal 'something went wrong.', e.message


### PR DESCRIPTION
Since most errors raised are subclasses of Exception rather than StandardError, we're not counting them. This PR makes sure we count _all_ of them.