### PR TITLE
I bet this was because of a low bundler pin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 cache: bundler
 rvm:
   - 2.3.3
+  - 2.5.0
 os:
   - linux
   - osx


### PR DESCRIPTION
Revert "whatever, something's going on with the 2.5.0 travis ruby and I don't think it's our code"

This reverts commit b9d39bcf5b5bd42ec2092150e3be254cba672e9f.