### PR TITLE
Revert to using bundler 1.17

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.0)
+  bundler (~> 1.17)
   byebug
   cli-kit!
   method_source

--- a/cli-kit.gemspec
+++ b/cli-kit.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'cli-ui', '>= 1.1.4'
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'minitest', '~> 5.0'
 end


### PR DESCRIPTION
Revert f993e834942e5e6cdadf7824b84169e34a89847b

Otherwise, bundler is confused and can't seem to be able to update
anything, complaining that:
```
Bundler could not find compatible versions for gem "bundler"
```