### PR TITLE
Update rubocop and fix linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,9 +12,6 @@ Style/ClassAndModuleChildren:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Shopify/RubocopComments:
-  Enabled: false
-
 # This doesn't understand that <<~ doesn't exist in 2.0
 Layout/IndentHeredoc:
   Enabled: false
@@ -37,8 +34,4 @@ Style/RegexpLiteral:
 
 # allow readable Dev::Util.begin formatting
 Style/MultilineBlockChain:
-  Enabled: false
-
-# allow using names to be more expressive
-Performance/RedundantBlockCall:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,9 @@ inherit_from:
   - http://shopify.github.io/ruby-style-guide/rubocop.yml
 
 AllCops:
-  Exclude: [ 'gen/template/**/*' ]
+  Exclude:
+    - gen/template/**/*
+    - vendor/**/*
   TargetRubyVersion: 2.3
 
 Style/ClassAndModuleChildren:

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development, :test do
-  gem 'rubocop', '~> 0.56.0'
+  gem 'rubocop'
   gem 'byebug'
   gem 'method_source'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
     builder (3.2.3)
     byebug (9.0.6)
     cli-ui (1.3.0)
+    jaro_winkler (1.5.3)
     metaclass (0.0.4)
     method_source (0.9.2)
     minitest (5.11.3)
@@ -22,21 +23,20 @@ GEM
       ruby-progressbar
     mocha (1.9.0)
       metaclass (~> 0.0.1)
-    parallel (1.12.1)
-    parser (2.5.1.0)
+    parallel (1.17.0)
+    parser (2.6.4.0)
       ast (~> 2.4.0)
-    powerpack (0.1.1)
     rainbow (3.0.0)
     rake (12.3.3)
-    rubocop (0.56.0)
+    rubocop (0.74.0)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5)
-      powerpack (~> 0.1)
+      parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
+      unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    unicode-display_width (1.3.2)
+    unicode-display_width (1.6.0)
 
 PLATFORMS
   ruby
@@ -50,7 +50,7 @@ DEPENDENCIES
   minitest-reporters
   mocha (~> 1.9.0)
   rake (~> 12.3)
-  rubocop (~> 0.56.0)
+  rubocop
 
 BUNDLED WITH
    1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,19 @@
-require "bundler/gem_tasks"
+$LOAD_PATH.unshift(File.expand_path('../lib', __FILE__))
+require 'rake/testtask'
+require 'rubocop/rake_task'
+require 'bundler/gem_tasks'
+
+TEST_ROOT = File.expand_path('../test', __FILE__)
+
+Rake::TestTask.new do |t|
+  t.libs += ["test"]
+  t.test_files = FileList[File.join(TEST_ROOT, '**', '*_test.rb')]
+  t.verbose = false
+  t.warning = false
+end
+
+RuboCop::RakeTask.new(:style) do |t|
+  t.options = ['--display-cop-names']
+end
+
+task(default: [:test, :style])

--- a/bin/testunit
+++ b/bin/testunit
@@ -14,7 +14,7 @@ end
 
 if ARGV.empty?
   test_files.each { |f| require(f) }
-  exit 0
+  exit(0)
 end
 
 # A list of files is presumed to be specified

--- a/cli-kit.gemspec
+++ b/cli-kit.gemspec
@@ -14,16 +14,16 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/shopify/cli-kit'
   spec.license       = 'MIT'
 
-  spec.files = `git ls-files -z`.split("\x0").reject do |f|
+  spec.files = %x(git ls-files -z).split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'cli-ui', '>= 1.1.4'
+  spec.add_runtime_dependency('cli-ui', '>= 1.1.4')
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
-  spec.add_development_dependency 'rake', '~> 12.3'
-  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency('bundler', '~> 1.17')
+  spec.add_development_dependency('rake', '~> 12.3')
+  spec.add_development_dependency('minitest', '~> 5.0')
 end

--- a/examples/minimal/example.rb
+++ b/examples/minimal/example.rb
@@ -5,7 +5,7 @@ require 'cli/kit'
 
 CLI::UI::StdoutRouter.enable
 
-include CLI::Kit
+include(CLI::Kit)
 
 registry = CommandRegistry.new(default: 'hello', contextual_resolver: nil)
 registry.add(Class.new(BaseCommand) do

--- a/gen/lib/gen/commands/help.rb
+++ b/gen/lib/gen/commands/help.rb
@@ -9,7 +9,7 @@ module Gen
 
         Gen::Commands::Registry.resolved_commands.each do |name, klass|
           puts CLI::UI.fmt("{{command:#{Gen::TOOL_NAME} #{name}}}")
-          if klass.respond_to?(:help) && help = klass.help
+          if klass.respond_to?(:help) && (help = klass.help)
             puts CLI::UI.fmt(help)
           end
           puts ""

--- a/gen/lib/gen/generator.rb
+++ b/gen/lib/gen/generator.rb
@@ -18,20 +18,20 @@ module Gen
     # false  -> delete file
     # string -> rename file before applying template substitutions
     VENDOR_TRANSLATIONS = {
-      'Gemfile'            => false,
-      'exe/__app__-gems'   => false,
+      'Gemfile' => false,
+      'exe/__app__-gems' => false,
       'exe/__app__-vendor' => 'exe/__app__',
-      'dev-gems.yml'       => false,
-      'dev-vendor.yml'     => 'dev.yml',
+      'dev-gems.yml' => false,
+      'dev-vendor.yml' => 'dev.yml',
     }.freeze
     private_constant :VENDOR_TRANSLATIONS
 
     BUNDLER_TRANSLATIONS = {
-      'bin/update-deps'    => false,
-      'exe/__app__-gems'   => 'exe/__app__',
+      'bin/update-deps' => false,
+      'exe/__app__-gems' => 'exe/__app__',
       'exe/__app__-vendor' => false,
-      'dev-gems.yml'       => 'dev.yml',
-      'dev-vendor.yml'     => false,
+      'dev-gems.yml' => 'dev.yml',
+      'dev-vendor.yml' => false,
     }.freeze
     private_constant :BUNDLER_TRANSLATIONS
 

--- a/lib/cli/kit.rb
+++ b/lib/cli/kit.rb
@@ -51,7 +51,7 @@ module CLI
     #       1. rescue Abort or Bug
     #       2. Print a contextualized error message
     #       3. Re-raise AbortSilent or BugSilent respectively.
-    GenericAbort = Class.new(Exception)
+    GenericAbort = Class.new(Exception) # rubocop:disable Lint/InheritException
     Abort        = Class.new(GenericAbort)
     Bug          = Class.new(GenericAbort)
     BugSilent    = Class.new(GenericAbort)

--- a/lib/cli/kit/autocall.rb
+++ b/lib/cli/kit/autocall.rb
@@ -11,8 +11,8 @@ module CLI
       def const_missing(const)
         block = begin
           @autocalls.fetch(const)
-        rescue KeyError
-          return super
+                rescue KeyError
+                  return super
         end
         const_set(const, block.call)
       end

--- a/lib/cli/kit/error_handler.rb
+++ b/lib/cli/kit/error_handler.rb
@@ -25,8 +25,8 @@ module CLI
         if notify_with = exception_for_submission(error)
           logs = begin
             File.read(@log_file)
-          rescue => e
-            "(#{e.class}: #{e.message})"
+                 rescue => e
+                   "(#{e.class}: #{e.message})"
           end
           exception_reporter.report(notify_with, logs)
         end

--- a/lib/cli/kit/error_handler.rb
+++ b/lib/cli/kit/error_handler.rb
@@ -22,7 +22,7 @@ module CLI
       end
 
       def handle_exception(error)
-        if notify_with = exception_for_submission(error)
+        if (notify_with = exception_for_submission(error))
           logs = begin
             File.read(@log_file)
                  rescue => e

--- a/lib/cli/kit/system.rb
+++ b/lib/cli/kit/system.rb
@@ -19,7 +19,7 @@ module CLI
         #
         def sudo_reason(msg)
           # See if sudo has a cached password
-          `env SUDO_ASKPASS=/usr/bin/false sudo -A true`
+          %x(env SUDO_ASKPASS=/usr/bin/false sudo -A true)
           return if $CHILD_STATUS.success?
           CLI::UI.with_frame_color(:blue) do
             puts(CLI::UI.fmt("{{i}} #{msg}"))


### PR DESCRIPTION
The linter hasn't been run for a while, the CI wasn't enforcing it.

Note that `Lint/InheritException` was _ignored_.
We purposefully want GenericAbort to skip bare `rescue => e`

See also https://github.com/Shopify/cli-ui/pull/78