### PR TITLE
Use a post openssl update ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.3
+  - 2.7.0
 os:
   - linux
   - osx

--- a/dev.yml
+++ b/dev.yml
@@ -1,5 +1,5 @@
 up:
-  - ruby: 2.3.3
+  - ruby: 2.7.0
   - bundler
 
 commands:


### PR DESCRIPTION
Travis hasn't recompiled old rubies linked against openssl 1.0 for mac, so use a ruby released after openssl was removed from homebrew.