### PR TITLE
Add debug environment variable name option to Logger

### DIFF
--- a/lib/cli/kit/logger.rb
+++ b/lib/cli/kit/logger.rb
@@ -10,9 +10,10 @@ module CLI
       # Constructor for CLI::Kit::Logger
       #
       # @param debug_log_file [String] path to the file where debug logs should be stored
-      def initialize(debug_log_file:)
+      def initialize(debug_log_file:, env_debug_name: 'DEBUG')
         FileUtils.mkpath(File.dirname(debug_log_file))
         @debug_logger = ::Logger.new(debug_log_file, MAX_NUM_LOGS, MAX_LOG_SIZE)
+        @env_debug_name = env_debug_name
       end
 
       # Functionally equivalent to Logger#info
@@ -60,7 +61,7 @@ module CLI
       #
       # @param msg [String] the message to log
       def debug(msg)
-        $stdout.puts CLI::UI.fmt(msg) if ENV['DEBUG']
+        $stdout.puts CLI::UI.fmt(msg) if is_debug?
         @debug_logger.debug(format_debug(msg))
       end
 
@@ -70,6 +71,11 @@ module CLI
         msg = CLI::UI.fmt(msg)
         return msg unless CLI::UI::StdoutRouter.current_id
         "[#{CLI::UI::StdoutRouter.current_id[:id]}] #{msg}"
+      end
+
+      def is_debug?
+        val = ENV[@env_debug_name]
+        val && val != '0' && val != ''
       end
     end
   end

--- a/test/cli/kit/logger_test.rb
+++ b/test/cli/kit/logger_test.rb
@@ -82,10 +82,56 @@ module CLI
         assert_debug_log_entry("hello", "DEBUG")
       end
 
+      def test_debug_with_debug_env_zero
+        with_env('DEBUG' => '0') do
+          out, err = capture_io do
+            @logger.debug("hello")
+          end
+          assert_empty(err.chomp)
+          assert_empty(out.chomp)
+          assert_debug_log_entry("hello", "DEBUG")
+        end
+      end
+
+      def test_debug_with_debug_env_empty
+        with_env('DEBUG' => '') do
+          out, err = capture_io do
+            @logger.debug("hello")
+          end
+          assert_empty(err.chomp)
+          assert_empty(out.chomp)
+          assert_debug_log_entry("hello", "DEBUG")
+        end
+      end
+
       def test_debug_with_debug_env
         with_env('DEBUG' => '1') do
           out, err = capture_io do
             @logger.debug("hello")
+          end
+          assert_equal "\e[0mhello", out.chomp
+          assert_empty err.chomp
+          assert_debug_log_entry("hello", "DEBUG")
+        end
+      end
+
+      def test_debug_without_custom_env_debug_name
+        logger = CLI::Kit::Logger.new(debug_log_file: @tmp_file.path, env_debug_name: 'FOO_DEBUG')
+        with_env('DEBUG' => '1') do
+          out, err = capture_io do
+            logger.debug("hello")
+          end
+          assert_empty(err.chomp)
+          assert_empty(out.chomp)
+          assert_debug_log_entry("hello", "DEBUG")
+        end
+      end
+
+      def test_debug_with_custom_env_debug_name
+        logger = CLI::Kit::Logger.new(debug_log_file: @tmp_file.path, env_debug_name: 'FOO_DEBUG')
+        with_env('FOO_DEBUG' => '1') do
+          out, err = capture_io do
+            logger.debug("hello")
           end
           assert_equal "\e[0mhello", out.chomp
           assert_empty err.chomp


### PR DESCRIPTION
Allows the user to specify the name of the environment variable that
determines whether debug is enabled or not.

Bonus: Debug is now considered disabled if the value is either empty or
set to '0' as expected.

example:

    CLI::Kit::Logger.new(
      debug_log_file: 'afile.log',
      env_debug_name: 'FOO_DEBUG'
    )