### PR TITLE
Fix resolve_path so that it also works on Windows

### DIFF
--- a/lib/cli/kit/system.rb
+++ b/lib/cli/kit/system.rb
@@ -174,14 +174,11 @@ module CLI
         end
 
         def os
-          require 'rbconfig'
+          return :mac if /darwin/.match(RUBY_PLATFORM)
+          return :linux if /linux/.match(RUBY_PLATFORM)
+          return :windows if /mingw32/.match(RUBY_PLATFORM)
 
-          host = RbConfig::CONFIG["host"]
-          return :mac if /darwin/.match(host)
-          return :linux if /linux/.match(host)
-          return :windows if /mingw32/.match(host)
-
-          raise "Could not determine OS from host #{host}"
+          raise "Could not determine OS from platform #{RUBY_PLATFORM}"
         end
 
         private
@@ -228,7 +225,7 @@ module CLI
           exts = os == :windows ? env.fetch('PATHEXT').split(';') : ['']
           env.fetch('PATH', '').split(File::PATH_SEPARATOR).each do |path|
             exts.each do |ext|
-              exe = File.join(File.expand_path(path), "#{cmd}#{ext}")
+              exe = File.join(path, "#{cmd}#{ext}")
               return exe if File.executable?(exe) && !File.directory?(exe)
             end
           end

--- a/lib/cli/kit/system.rb
+++ b/lib/cli/kit/system.rb
@@ -173,6 +173,17 @@ module CLI
           [data.byteslice(0...partial_character_index), data.byteslice(partial_character_index..-1)]
         end
 
+        def os
+          require 'rbconfig'
+
+          host = RbConfig::CONFIG["host"]
+          return :mac if /darwin/.match(host)
+          return :linux if /linux/.match(host)
+          return :windows if /mingw32/.match(host)
+
+          raise "Could not determine OS from host #{host}"
+        end
+
         private
 
         def apply_sudo(*a, sudo)
@@ -199,17 +210,30 @@ module CLI
         # See https://github.com/Shopify/dev/pull/625 for more details.
         def resolve_path(a, env)
           # If only one argument was provided, make sure it's interpreted by a shell.
-          return ["true ; " + a[0]] if a.size == 1
+          if a.size == 1
+            if os == :windows
+              return ["break && " + a[0]]
+            else
+              return ["true ; " + a[0]]
+            end
+          end
           return a if a.first.include?('/')
 
-          paths = env.fetch('PATH', '').split(':')
-          item = paths.detect do |f|
-            command_path = "#{f}/#{a.first}"
-            File.executable?(command_path) && File.file?(command_path)
+          item = which(a.first, env)
+          a[0] = item if item
+          a
+        end
+
+        def which(cmd, env)
+          exts = os == :windows ? env.fetch('PATHEXT').split(';') : ['']
+          env.fetch('PATH', '').split(File::PATH_SEPARATOR).each do |path|
+            exts.each do |ext|
+              exe = File.join(File.expand_path(path), "#{cmd}#{ext}")
+              return exe if File.executable?(exe) && !File.directory?(exe)
+            end
           end
 
-          a[0] = "#{item}/#{a.first}" if item
-          a
+          nil
         end
       end
     end

--- a/test/cli/kit/system_test.rb
+++ b/test/cli/kit/system_test.rb
@@ -53,12 +53,11 @@ module CLI
 
         with_script_in_tmpdir("ruby") do |tmpdir|
           path = tmpdir
-          path = path.gsub(/\//, '\\') if CLI::Kit::System.os == :windows
           with_env("PATH" => "#{path}#{File::PATH_SEPARATOR}#{ENV['PATH']}") do
             out, stat = System.capture2("ruby", "-e", "puts 'system ruby'", env: ENV)
 
             assert stat, message: "expected command to successfully run"
-            assert_equal "from script", out.split("\n")[-1] # Windows prints the command before the output
+            assert_equal "from script", out.split("\n")[-1] # Windows prints the command before the output so we skip it
           end
         end
       end
@@ -68,12 +67,11 @@ module CLI
 
         with_script_in_tmpdir("ruby") do |tmpdir|
           path = tmpdir
-          path = path.gsub(/\//, '\\') if CLI::Kit::System.os == :windows
           with_env("PATH" => "#{path}#{File::PATH_SEPARATOR}#{ENV['PATH']}") do
             out, stat = System.capture2("ruby -e 'puts \"system ruby\"'", env: ENV)
 
             assert stat, message: "expected command to successfully run"
-            assert_equal "from script", out.split("\n")[-1] # Windows prints the command before the output
+            assert_equal "from script", out.split("\n")[-1] # Windows prints the command before the output so we skip it
           end
         end
       end


### PR DESCRIPTION
We are adapting the Shopify CLI (https://github.com/Shopify/shopify-app-cli) to work natively on Windows. While making those changes, we ran into an issue on `system.rb` where we could run commands as `true ; <cmd>` in some scenarios.

Windows treats that as an invalid command, and thus fails to actually run the desired command. To work around this issue, I propose we check if the CLI is running under Windows and run `break && <cmd>` instead.

This PR does not add any tests because testing this change on Mac / Linux doesn't fully make sense since the tests run actual commands on the machine. I did, however, 🎩  the tests on Windows and while a couple of unrelated things fail (SIGQUIT doesn't exist on windows, and the suggestions for the resolver come out in a different order on Windows), the tests around calling commands do work after a bit of tweaking.