### PR TITLE
Correct return value for `system` call in Rubydoc

### DIFF
--- a/lib/cli/kit/system.rb
+++ b/lib/cli/kit/system.rb
@@ -112,7 +112,7 @@ module CLI
         # - `**kwargs`: additional keyword arguments to pass to Process.spawn
         #
         # #### Returns
-        # - `status`: boolean success status of the command execution
+        # - `status`: The `Process:Status` result for the command execution
         #
         # #### Usage
         # `stat = CLI::Kit::System.system('ls', 'a_folder')`


### PR DESCRIPTION
The return value `$CHILD_STATUS` isn't a boolean, it's an instance of `Process::Status`