### PR TITLE
Handle not being able to install a signal handler

### DIFF
--- a/lib/cli/kit/executor.rb
+++ b/lib/cli/kit/executor.rb
@@ -51,10 +51,17 @@ module CLI
         return yield unless Signal.list.key?(signal)
 
         begin
-          prev_handler = trap(signal, handler)
+          begin
+            prev_handler = trap(signal, handler)
+            installed = true
+          rescue ArgumentError
+            # If we couldn't install a signal handler because the signal is
+            # reserved, remember not to uninstall it later.
+            installed = false
+          end
           yield
         ensure
-          trap(signal, prev_handler)
+          trap(signal, prev_handler) if installed
         end
       end
 


### PR DESCRIPTION
`Signal.trap` can't always install a signal handler. If it can't you need to remember not to try to uninstall it later.

My specific motivation is supporting TruffleRuby, but the MRI also raises `ArgumentError` for some other signals, so it's an established pattern.