### PR TITLE
Add helpful message to `NotImplementedError`

### DIFF
--- a/lib/cli/kit/base_command.rb
+++ b/lib/cli/kit/base_command.rb
@@ -38,7 +38,7 @@ module CLI
       end
 
       def call(_args, _command_name)
-        raise NotImplementedError
+        raise NotImplementedError, "#{self.class.name} must implement #{__method__}"
       end
 
       def has_subcommands?


### PR DESCRIPTION
Raising the error without a message results in a backtrace pointing to the parent class. It is useful to highlight the exact class that needs to implement the method instead.

Spinoff of Shopify/dev#6125.