### PR TITLE
Fix get bool

### DIFF
--- a/lib/cli/kit/config.rb
+++ b/lib/cli/kit/config.rb
@@ -34,6 +34,8 @@ module CLI
           true
         when 'false'
           false
+        when default
+          default
         else
           raise CLI::Kit::Abort, "Invalid config: #{section}.#{name} is expected to be true or false"
         end

--- a/lib/cli/kit/config.rb
+++ b/lib/cli/kit/config.rb
@@ -29,7 +29,7 @@ module CLI
 
       # Coalesce and enforce the value of a config to a boolean
       def get_bool(section, name, default: false)
-        case get(section, name, default: default).to_s
+        case get(section, name, default: default)
         when 'true'
           true
         when 'false'

--- a/test/cli/kit/config_test.rb
+++ b/test/cli/kit/config_test.rb
@@ -59,6 +59,15 @@ module CLI
         assert_equal('Invalid config: section.foo-key is expected to be true or false', e.message)
       end
 
+      def test_get_bool_on_default_nil_unset
+        assert_nil(@config.get_bool('section', 'foo-key', default: nil))
+      end
+
+      def test_get_bool_on_default_nil_set_false
+        @config.set('section', 'foo-key', false)
+        assert_equal(false, @config.get_bool('section', 'foo-key', default: nil))
+      end
+
       def test_config_key_never_padded_with_whitespace
         # There was a bug that occured when a key was reset
         # We split on `=` and 'key ' became the new key (with a space)


### PR DESCRIPTION
Allows the reasonable use of `get_bool(section, name, default: nil)` to get a `T.nilable(T::Boolean)` so you can detect the difference between something being explicitly configured as false vs not having been configured.