### PR TITLE
Fix docs to replace Bugsnag with exception_reporter

### DIFF
--- a/lib/cli/kit.rb
+++ b/lib/cli/kit.rb
@@ -28,7 +28,8 @@ module CLI
     # a bare `rescue => e`.
     #
     # * Abort prints its message in red and exits 1;
-    # * Bug additionally submits the exception to Bugsnag;
+    # * Bug additionally submits the exception to the exception_reporter passed to
+    #     `CLI::Kit::ErrorHandler.new`
     # * AbortSilent and BugSilent do the same as above, but do not print
     #     messages before exiting.
     #


### PR DESCRIPTION
Bugsnag is one potential use for the exception reporter, but not the generic CLI::Kit thing.