### PR TITLE
Fix split partial characters

### DIFF
--- a/test/cli/kit/system_test.rb
+++ b/test/cli/kit/system_test.rb
@@ -35,6 +35,12 @@ module CLI
         assert_equal([str, ''], System.split_partial_characters(str))
       end
 
+      def test_split_partial_characters_when_ending_in_multibyte_character
+        str = 'ルビ'
+
+        assert_equal([str, ''], System.split_partial_characters(str))
+      end
+
       def test_system_finds_system_ruby_instead_of_local_script
         CLI::Kit::System.fake('ruby', '-e', "puts 'system ruby'", allow: true)
 


### PR DESCRIPTION
If the string ended in a full multibyte character, we'd return it in trailing, which could result in a command whose output ended in a multibyte character having the character stripped.