### PR TITLE
Allow '-' as a positional argument.

### DIFF
--- a/lib/cli/kit/args/tokenizer.rb
+++ b/lib/cli/kit/args/tokenizer.rb
@@ -73,13 +73,13 @@ module CLI
                 case arg
                 when '--'
                   mode = :unparsed
-                when /\A--/
+                when /\A--./
                   name, value = arg.split('=', 2)
                   args << Token::LongOptionName.new(T.must(T.must(name)[2..-1]))
                   if value
                     args << Token::OptionValue.new(value)
                   end
-                when /\A-/
+                when /\A-./
                   args.concat(tokenize_short_option(T.must(arg[1..-1])))
                 else
                   args << if args.last.is_a?(Token::OptionName)

--- a/test/cli/kit/args/tokenizer_test.rb
+++ b/test/cli/kit/args/tokenizer_test.rb
@@ -10,6 +10,7 @@ module CLI
           check('-a', [Token::ShortOptionName.new('a')])
           check('--b', [Token::LongOptionName.new('b')])
           check('c', [Token::PositionalArgument.new('c')])
+          check('-', [Token::PositionalArgument.new('-')])
           assert_raises(Tokenizer::InvalidCharInShortOption) { Tokenizer.tokenize(['-@']) }
         end
 


### PR DESCRIPTION
`-` is often used as a placeholder for stdin.