### PR TITLE
Add support for multi_option defaults

### DIFF
--- a/lib/cli/kit/args/definition.rb
+++ b/lib/cli/kit/args/definition.rb
@@ -34,7 +34,12 @@ module CLI
         sig do
           params(
             name: Symbol, short: T.nilable(String), long: T.nilable(String),
-            desc: T.nilable(String), default: T.any(NilClass, String, T.proc.returns(String)),
+            desc: T.nilable(String),
+            default: T.any(
+              NilClass,
+              String, T.proc.returns(String),
+              T::Array[String], T.proc.returns(T::Array[String]),
+            ),
             required: T::Boolean, multi: T::Boolean,
           ).void
         end
@@ -95,7 +100,7 @@ module CLI
         module OptValue
           extend T::Sig
 
-          sig { returns(T.nilable(String)) }
+          sig { returns(T.any(NilClass, String, T::Array[String])) }
           def default
             if @default.is_a?(Proc)
               @default.call
@@ -204,13 +209,18 @@ module CLI
           sig do
             params(
               name: Symbol, short: T.nilable(String), long: T.nilable(String),
-              desc: T.nilable(String), default: T.any(NilClass, String, T.proc.returns(String)),
+              desc: T.nilable(String),
+              default: T.any(
+                NilClass,
+                String, T.proc.returns(String),
+                T::Array[String], T.proc.returns(T::Array[String]),
+              ),
               required: T::Boolean, multi: T::Boolean,
             ).void
           end
           def initialize(name:, short: nil, long: nil, desc: nil, default: nil, required: false, multi: false)
-            if multi && (default || required)
-              raise(ArgumentError, 'multi-valued options cannot have a default or required value')
+            if multi && required
+              raise(ArgumentError, 'multi-valued options cannot have a required value')
             end
 
             super(name: name, short: short, long: long, desc: desc)

--- a/lib/cli/kit/args/evaluation.rb
+++ b/lib/cli/kit/args/evaluation.rb
@@ -204,9 +204,9 @@ module CLI
               parse.select { |node| node.is_a?(Parser::Node::ShortOption) },
               T::Array[Parser::Node::ShortOption],
             )
-            matches = opts.reverse.select { |node| node.name == opt.short }
-            if (first = matches.first)
-              return(opt.multi? ? matches.map(&:value) : first.value)
+            matches = opts.select { |node| node.name == opt.short }
+            if (last = matches.last)
+              return(opt.multi? ? matches.map(&:value) : last.value)
             end
           end
           if opt.long
@@ -214,12 +214,12 @@ module CLI
               parse.select { |node| node.is_a?(Parser::Node::LongOption) },
               T::Array[Parser::Node::LongOption],
             )
-            matches = opts.reverse.select { |node| node.name == opt.long }
-            if (first = matches.first)
-              return(opt.multi? ? matches.map(&:value) : first.value)
+            matches = opts.select { |node| node.name == opt.long }
+            if (last = matches.last)
+              return(opt.multi? ? matches.map(&:value) : last.value)
             end
           end
-          opt.multi? ? [] : opt.default
+          opt.default
         end
 
         sig { params(position: Definition::Position).returns(T.any(NilClass, String, T::Array[String])) }

--- a/lib/cli/kit/opts.rb
+++ b/lib/cli/kit/opts.rb
@@ -97,13 +97,14 @@ module CLI
             short: T.nilable(String),
             long: T.nilable(String),
             desc: T.nilable(String),
+            default: T.any(T::Array[String], T.proc.returns(T::Array[String])),
           ).returns(T::Array[String])
         end
-        def multi_option(name: infer_name, short: nil, long: nil, desc: nil)
+        def multi_option(name: infer_name, short: nil, long: nil, desc: nil, default: [])
           case @obj
           when Args::Definition
             @obj.add_option(
-              name, short: short, long: long, desc: desc, multi: true,
+              name, short: short, long: long, desc: desc, default: default, multi: true,
             )
             ['(result unavailable)']
           when Args::Evaluation

--- a/test/cli/kit/args/evaluation_test.rb
+++ b/test/cli/kit/args/evaluation_test.rb
@@ -15,6 +15,7 @@ module CLI
           @defn.add_flag(:print, long: '--print')
           @defn.add_flag(:verbose, long: '--verbose')
           @defn.add_option(:output, short: '-o', default: 'text')
+          @defn.add_option(:multi_default, short: '-m', multi: true, default: ['a'])
           @defn.add_option(:notprovided, short: '-n')
           @defn.add_position(:first, required: true, multi: false)
           @defn.add_position(:second, required: false, multi: false, skip: ->(arg) { arg == 'b' })
@@ -44,6 +45,7 @@ module CLI
           assert_equal('200', evl.opt.zk)
           assert_equal('3', evl.opt.height)
           assert_equal('text', evl.opt.output)
+          assert_equal(['a'], evl.opt.multi_default)
           refute(evl.opt.notprovided)
           assert_raises(NameError) { evl.opt.foobar }
           assert_raises(NameError) { evl.flag.foobar }

--- a/test/cli/kit/opts_test.rb
+++ b/test/cli/kit/opts_test.rb
@@ -74,6 +74,16 @@ module CLI
         end
       end
 
+      class MultiDefaultOpts < CLI::Kit::Opts
+        def multi
+          multi_option(long: '--multi', default: -> { no_multi? ? [] : ['default'] })
+        end
+
+        def no_multi?
+          flag(long: '--no-multi')
+        end
+      end
+
       def test_stuff
         opts = TestOpts.new
         defn = Args::Definition.new
@@ -130,6 +140,29 @@ module CLI
         assert_equal('a', opts.first)
         assert_equal('b', opts.second)
         assert_equal('c', opts.third)
+      end
+
+      def test_multi_default
+        opts = MultiDefaultOpts.new
+        defn = Args::Definition.new
+        opts.define!(defn)
+        evl = evaluate(defn, '')
+        opts.evaluate!(evl)
+        assert_equal(['default'], opts.multi)
+
+        defn = Args::Definition.new
+        opts = MultiDefaultOpts.new
+        opts.define!(defn)
+        evl = evaluate(defn, '--no-multi')
+        opts.evaluate!(evl)
+        assert_equal([], opts.multi)
+
+        defn = Args::Definition.new
+        opts = MultiDefaultOpts.new
+        opts.define!(defn)
+        evl = evaluate(defn, '--multi a --multi b')
+        opts.evaluate!(evl)
+        assert_equal(['a', 'b'], opts.multi)
       end
 
       private


### PR DESCRIPTION
This also fixes a bug where multi_option values were returned in reverse order.

If any values are provided, the default is overridden, not extended. If you'd
like to support zeroing out the default value, you can do so by adding a
corresponding --no-<multi_option> flag like so:

```ruby
class Opts < CLI::Kit::Opts
  def multi
    multi_option(long: '--multi', default: -> { no_multi? ? [] : ['default'] })
  end

  def no_multi?
    flag('--no-multi')
  end
end
```