### PR TITLE
Handle EIO in ErrorHandler

### DIFF
--- a/lib/cli/kit/error_handler.rb
+++ b/lib/cli/kit/error_handler.rb
@@ -164,7 +164,7 @@ module CLI
       sig { params(message: String).void }
       def stderr_puts(message)
         $stderr.puts(CLI::UI.fmt("{{red:#{message}}}"))
-      rescue Errno::EPIPE
+      rescue Errno::EPIPE, Errno::EIO
         nil
       end
 


### PR DESCRIPTION
EIO errors can pop up when the fd closes, e.g. when you close a terminal.