### PR TITLE
Update to the latest stable ruby version in the dev yml templates

### DIFF
--- a/gen/template/dev-gems.yml
+++ b/gen/template/dev-gems.yml
@@ -1,3 +1,3 @@
 up:
-  - ruby: 2.5.0
+  - ruby: 3.2.2
   - bundler

--- a/gen/template/dev-vendor.yml
+++ b/gen/template/dev-vendor.yml
@@ -1,4 +1,4 @@
 up:
-  - ruby: 2.5.0
+  - ruby: 3.2.2
 
 build: bin/update-deps


### PR DESCRIPTION
Ran into issues when creating new cli projects with `cli-kit new myproject` because the ruby version in the dev template is 5 years old. 

### Tophat:
1. Update the first line of `cli-kit` in exe dir to `#!/usr/bin/env ruby`
2. `./exe/cli-kit new myproject` generates `dev.yml` that has ruby `3.2.2`

