### PR TITLE
Add `x64-mingw32` to fix Windows CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   universal-darwin
+  x64-mingw32
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
PRs are failing on [errors like this one](https://github.com/Shopify/cli-kit/actions/runs/5246040090/jobs/9474325872#step:3:63):

```
> bundle install
C:\Windows\system32\cmd.exe /D /S /C "C:\hostedtoolcache\windows\Ruby\3.0.6\x64\bin\bundle.bat config --local path D:\a\cli-kit\cli-kit\vendor\bundle"
C:\Windows\system32\cmd.exe /D /S /C "C:\hostedtoolcache\windows\Ruby\3.0.6\x64\bin\bundle.bat config --local deployment true"
Cache key: setup-ruby-bundler-cache-v6-windows-2022-x64-ruby-3.0.6-wd-D:\a\cli-kit\cli-kit-with--without-typecheck-Gemfile.lock-c[50](https://github.com/Shopify/cli-kit/actions/runs/5246040090/jobs/9474325872#step:3:59)816874291ecc14eeed80a7488b576dc2a0c256036654718e9d6633729a895
C:\Windows\system32\cmd.exe /D /S /C "C:\hostedtoolcache\windows\Ruby\3.0.6\x64\bin\bundle.bat install --jobs 4"
Your bundle only supports platforms ["arm64-darwin-21", "universal-darwin",
"x86_64-linux"] but your local platform is x64-mingw32. Add the current platform
to the lockfile with
`bundle lock --add-platform x64-mingw32` and try again.
Error: The process 'C:\hostedtoolcache\windows\Ruby\3.0.6\x64\bin\bundle.bat' failed with exit code 16
```

I'm just following the steps recommended by that message 🤷 