### PR TITLE
Drop ruby 2.7 from CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        ruby-version: ['2.7', '3.0']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3']
 
     runs-on: ${{ matrix.os }}
     env:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   universal-darwin
+  x64-mingw-ucrt
   x64-mingw32
   x86_64-linux
 


### PR DESCRIPTION
`rubocop-sorbet` now requires ruby 3+