### PR TITLE
Don't wait for Process to end twice in system.rb

### DIFF
--- a/lib/cli/kit/system.rb
+++ b/lib/cli/kit/system.rb
@@ -240,7 +240,7 @@ module CLI
             break if Process.wait(pid, Process::WNOHANG)
 
             ios = [err_r, out_r].reject(&:closed?)
-            break if ios.empty?
+            next if ios.empty?
 
             readers, = IO.select(ios, [], [], 1)
             next if readers.nil? # If IO.select times out we iterate again so we can check if the process has exited
@@ -254,7 +254,6 @@ module CLI
             end
           end
 
-          Process.wait(pid)
           $CHILD_STATUS
         end
 


### PR DESCRIPTION
Fixing an issue from: https://github.com/Shopify/cli-kit/pull/501

We introduced a possible defect where we do `Process.wait` twice which will raise an error.

For example: https://github.com/Shopify/dev/actions/runs/10474839936/job/29010052542?pr=10051

Let's remove the `Process.wait` after the `loop`. That means, if both the IO are `closed` then we just `next` instead of `break`, and then the loop will exit after `Process.wait` returns `true`.