### PR TITLE
Refines ParseArgs

### DIFF
--- a/lib/cli/kit/parse_args.rb
+++ b/lib/cli/kit/parse_args.rb
@@ -18,7 +18,7 @@ module CLI
           opts_defn: T::Hash[Symbol, T::Array[T.untyped]],
         ).returns(T::Hash[Symbol, T.untyped])
       end
-      def parse_args(args, opts_defn)
+      def parse_args(args, opts_defn = {})
         start_opts, parser_config = opts_defn.reduce([{}, []]) do |(ini, pcfg), (n, cfg)|
           (vals, desc, short, klass) = cfg
           (init_val, def_val) = Array(vals)

--- a/test/cli/kit/parse_args_test.rb
+++ b/test/cli/kit/parse_args_test.rb
@@ -26,6 +26,10 @@ module CLI
         def call(args)
           @args = parse_args(args, OPTS)
         end
+
+        def call_no_opts(args)
+          @args = parse_args(args)
+        end
       end
 
       def setup
@@ -45,6 +49,17 @@ module CLI
         assert_equal(
           { maybe: false, sum: 11, str: 'foo', opt: 'init_val', snake_squad_alpha: 'snakes' },
           @cmd.args[:opts],
+        )
+      end
+
+      def test_no_opts
+        @cmd.call_no_opts('one two')
+        assert_equal(
+          {
+            opts: {},
+            sub: ['one', 'two'],
+          },
+          @cmd.args,
         )
       end
 


### PR DESCRIPTION
- Provide a default value for `opts_defn`
- Accept `Array` as a value for `args`