### PR TITLE
Make single-arg commands killable

### DIFF
--- a/lib/cli/kit/system.rb
+++ b/lib/cli/kit/system.rb
@@ -366,7 +366,7 @@ module CLI
         def resolve_path(cmd, args, env)
           # If only one argument was provided, make sure it's interpreted by a shell.
           if args.empty?
-            prefix = os == :windows ? 'break && ' : 'true ; '
+            prefix = os == :windows ? 'break && ' : 'true && '
             return [prefix + cmd, []]
           end
           return [cmd, args] if cmd.include?('/')


### PR DESCRIPTION
Prepending `true ; ` means that attempts to kill the invoked command will actually just kill `true`, and leave the underlying command running. The workaround for that was to pass `pgroup: true` and kill the whole group, but ideally we don't need to do that.