### PR TITLE
Allow subclassing Opts

### DIFF
--- a/lib/cli/kit/command_help.rb
+++ b/lib/cli/kit/command_help.rb
@@ -134,14 +134,6 @@ module CLI
           opts = opts_class
           return unless opts
 
-          methods = []
-          loop do
-            methods.concat(opts.public_instance_methods(false))
-            break if opts.superclass == CLI::Kit::Opts
-
-            opts = opts.superclass
-          end
-
           @defn = Args::Definition.new
           o = opts.new
           o.define!(@defn)

--- a/test/cli/kit/command_help_test.rb
+++ b/test/cli/kit/command_help_test.rb
@@ -19,7 +19,20 @@ module CLI
 
         example('-q -u neato', "quietly do a thing with 'neato'")
 
-        class Opts < CLI::Kit::Opts
+        class BaseOpts < CLI::Kit::Opts
+          class << self
+            def inherited(subclass)
+              super
+              subclass.class_eval do
+                def dry_run
+                  flag(short: '-d', desc: 'dry run')
+                end
+              end
+            end
+          end
+        end
+
+        class Opts < BaseOpts
           def quiet
             flag(short: '-q', desc: 'be quiet')
           end
@@ -47,6 +60,7 @@ module CLI
             \e[0;36mtest a-command\e[0m -q -u neato  \e[0;3;38;5;244m# quietly do a thing with 'neato'\e[0m
 
           \e[0;1mOptions:\e[0m
+            -d  \e[0;3;38;5;244m# dry run\e[0m
             -h, --help  \e[0;3;38;5;244m# Show this help message\e[0m
             -l, --loud  \e[0;3;38;5;244m# be loud\e[0m
             -q  \e[0;3;38;5;244m# be quiet\e[0m


### PR DESCRIPTION
In our app, we have code that looks like:

```ruby
class AppOpts < CLI::Kit::Opts
  def self.inherited(subclass)
    subclass.class_eval do
      def global_flag = flag(short: '-g', desc: 'some global flag')
    end
  end
end

class SomeCommand
  class Opts < AppOpts
    def specific = flag(short: '-s', desc: 'command specific flag')
  end
end
```

The options work as expected, but child options do not show up in `--help` because we loop through superclasses and only grab the direct children of `CLI::Kit::Opts` for documentation purpose. As we do that, we also accumualte method names into an array that's not read.

This looks like a bug / indead that never panned out, so I'm removing these lines.