### PR TITLE
Walk exception cause chain to filter benign signals wrapped by finalizer errors

### DIFF
--- a/lib/cli/kit/error_handler.rb
+++ b/lib/cli/kit/error_handler.rb
@@ -114,12 +114,20 @@ module CLI
         e.bug? ? CLI::Kit::EXIT_BUG : CLI::Kit::EXIT_FAILURE_BUT_NOT_BUG
       end
 
+      #: (Exception? error) -> bool
+      def caused_by_benign_signal?(error)
+        current = error #: Exception?
+        while current
+          return true if current.is_a?(SignalException) && SIGNALS_THAT_ARENT_BUGS.include?(current.message)
+
+          current = current.cause
+        end
+        false
+      end
+
       #: (Exception? error) -> Exception?
       def exception_for_submission(error)
-        # happens on normal non-error termination
-        return if error.nil?
-
-        return unless error.bug?
+        return if error.nil? || !error.bug? || caused_by_benign_signal?(error)
 
         case error
         when SignalException

--- a/test/cli/kit/error_handler_test.rb
+++ b/test/cli/kit/error_handler_test.rb
@@ -176,6 +176,39 @@ module CLI
         skip
       end
 
+      def test_benign_signal_wrapped_by_epipe_is_not_reported
+        # When a finalizer raises Errno::EPIPE after a SIGTERM, the EPIPE
+        # becomes the top-level exception with SIGTERM as its cause.
+        # The error handler should still filter it as benign.
+        wrapped_error = build_wrapped_error(
+          cause: SignalException.new('SIGTERM'),
+          outer: Errno::EPIPE,
+        )
+
+        @rep.expects(:report).never
+        @eh.report_exception(wrapped_error)
+      end
+
+      def test_benign_signal_wrapped_by_ebadf_is_not_reported
+        wrapped_error = build_wrapped_error(
+          cause: SignalException.new('SIGHUP'),
+          outer: Errno::EBADF,
+        )
+
+        @rep.expects(:report).never
+        @eh.report_exception(wrapped_error)
+      end
+
+      def test_non_benign_signal_wrapped_is_still_reported
+        wrapped_error = build_wrapped_error(
+          cause: SignalException.new('SIGSEGV'),
+          outer: Errno::EPIPE,
+        )
+
+        @rep.expects(:report).once
+        @eh.report_exception(wrapped_error)
+      end
+
       def test_bug_signal
         # e.g. SIGSEGV
         skip
@@ -194,6 +227,15 @@ module CLI
       end
 
       private
+
+      # Builds an exception where `outer` has `cause` as its cause.
+      # We can't use raise/rescue with SignalException because Ruby
+      # actually delivers the signal. Instead, we stub #cause.
+      def build_wrapped_error(cause:, outer:)
+        error = outer.is_a?(Exception) ? outer : outer.new
+        error.define_singleton_method(:cause) { cause }
+        error
+      end
 
       def error_handler(tool_name: nil, dev_mode: false)
         ErrorHandler.new(


### PR DESCRIPTION
When a process receives SIGTERM/SIGHUP/SIGINT, an ensure block (e.g. Dev::Finalize.deliver!) can raise a secondary exception such as Errno::EPIPE or Errno::EBADF when it tries to write to a closed stderr. This secondary exception replaces the original SignalException as the top-level error, but keeps it accessible via Exception#cause.

Previously, exception_for_submission only checked the top-level exception for SignalException, so these wrapped signals fell through to the else branch and were incorrectly reported as bugs.

Add caused_by_benign_signal? which walks the entire cause chain, so SIGTERM/SIGHUP/SIGINT are still filtered even when buried as a cause.

Co-authored-by: Claude <noreply@anthropic.com>
